### PR TITLE
Now using holster.Clock instead of timetools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _testmain.go
 
 *.exe
 *.test
+.idea

--- a/client.go
+++ b/client.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-
 	"runtime"
 	"strconv"
-
 	"sync"
 	"time"
 )


### PR DESCRIPTION
## Purpose
timetools has a hard dependency on `mgo` the golang mongodb library. This change removes that hard dependency by using `holster.Clock` instead of `timetools.TimeProvider`

